### PR TITLE
Simple patch to configure Bind PDU params (address_range, addr_ton, addr_npi)

### DIFF
--- a/smpp/twisted/config.py
+++ b/smpp/twisted/config.py
@@ -28,3 +28,6 @@ class SMPPClientConfig(object):
         self.pduReadTimerSecs = kwargs.get('pduReadTimerSecs', 10)
         self.useSSL = kwargs.get('useSSL', False)
         self.SSLCertificateFile = kwargs.get('SSLCertificateFile', None)
+        self.addressRange = kwargs.get('addressRange', None)
+        self.addressTon = kwargs.get('addressTon', None)
+        self.addressNpi = kwargs.get('addressNpi', None)

--- a/smpp/twisted/examples/transceiver.py
+++ b/smpp/twisted/examples/transceiver.py
@@ -8,6 +8,9 @@ class SMPP(object):
     def __init__(self, config=None):
         if config is None:
             config = SMPPClientConfig(host='localhost', port=999, username='uname', password='pwd')
+
+            # Uncomment line below to recv SMS via #322223322 only
+            # config = SMPPClientConfig(host='localhost', port=999, username='uname', password='pwd', addressTon=AddrTon.UNKNOWN, addressNpi=AddrNpi.ISDN, addressRange='^322223322$')
         self.config = config
         
     @defer.inlineCallbacks

--- a/smpp/twisted/protocol.py
+++ b/smpp/twisted/protocol.py
@@ -527,6 +527,9 @@ class SMPPClientProtocol( protocol.Protocol ):
             system_id = self.config().username,
             password = self.config().password, 
             system_type = self.config().systemType,
+            address_range = self.config().addressRange,
+            addr_ton = self.config().addressTon,
+            addr_npi = self.config().addressNpi,
             interface_version = self.version
         )
         return self.bind(pdu, SMPPSessionStates.BIND_RX_PENDING, SMPPSessionStates.BOUND_RX)
@@ -544,6 +547,9 @@ class SMPPClientProtocol( protocol.Protocol ):
             system_id = self.config().username, 
             password = self.config().password, 
             system_type = self.config().systemType,
+            address_range = self.config().addressRange,
+            addr_ton = self.config().addressTon,
+            addr_npi = self.config().addressNpi,
             interface_version = self.version
         )
         return self.bind(pdu, SMPPSessionStates.BIND_TX_PENDING, SMPPSessionStates.BOUND_TX)
@@ -567,6 +573,9 @@ class SMPPClientProtocol( protocol.Protocol ):
             system_id = self.config().username, 
             password = self.config().password,
             system_type = self.config().systemType,
+            address_range = self.config().addressRange,
+            addr_ton = self.config().addressTon,
+            addr_npi = self.config().addressNpi,
             interface_version = self.version
         )
         return self.bind(pdu, SMPPSessionStates.BIND_TRX_PENDING, SMPPSessionStates.BOUND_TRX)


### PR DESCRIPTION
It is allowed to configure Bind's address_range, addr_ton, addr_npi parameters
using new SMPPClientConfig's members (addressRange, addressTon and addressNpi)
