### PR TITLE
Added SMPP server, server tests and minor logging changes

### DIFF
--- a/smpp/twisted/client.py
+++ b/smpp/twisted/client.py
@@ -128,6 +128,7 @@ class SMPPClientService(service.Service):
     def __init__(self, smppClient):
         self.client = smppClient
         self.stopDeferred = defer.Deferred()
+        self.log = logging.getLogger(LOG_CATEGORY)
         
     def getStopDeferred(self):
         return self.stopDeferred
@@ -148,5 +149,6 @@ class SMPPClientService(service.Service):
     def stopService(self):
         service.Service.stopService(self)
         if self.client.smpp:
+            self.log.info("Stopping SMPP Client")
             return self.client.smpp.unbindAndDisconnect()
 

--- a/smpp/twisted/config.py
+++ b/smpp/twisted/config.py
@@ -13,21 +13,42 @@ Copyright 2009-2010 Mozes, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-class SMPPClientConfig(object):
+class SMPPConfig(object):
     
     def __init__(self, **kwargs):
-        self.host = kwargs['host']
-        self.port = kwargs['port']
-        self.username = kwargs['username']
-        self.password = kwargs['password']
-        self.systemType = kwargs.get('systemType', '')
         self.sessionInitTimerSecs = kwargs.get('sessionInitTimerSecs', 30)
         self.enquireLinkTimerSecs = kwargs.get('enquireLinkTimerSecs', 10)
         self.inactivityTimerSecs = kwargs.get('inactivityTimerSecs', 120)
         self.responseTimerSecs = kwargs.get('responseTimerSecs', 60)
         self.pduReadTimerSecs = kwargs.get('pduReadTimerSecs', 10)
+
+
+class SMPPClientConfig(SMPPConfig):
+    
+    def __init__(self, **kwargs):
+        super(SMPPClientConfig, self).__init__(**kwargs)
+        self.port = kwargs['port']
+        self.host = kwargs['host']
+        self.username = kwargs['username']
+        self.password = kwargs['password']
+        self.systemType = kwargs.get('systemType', '')
         self.useSSL = kwargs.get('useSSL', False)
         self.SSLCertificateFile = kwargs.get('SSLCertificateFile', None)
         self.addressRange = kwargs.get('addressRange', None)
         self.addressTon = kwargs.get('addressTon', None)
-        self.addressNpi = kwargs.get('addressNpi', None)
+        self.addressNpi = kwargs.get('addressNpi', None)        
+
+class SMPPServerConfig(SMPPConfig):
+    
+    def __init__(self, **kwargs):
+        """
+        @param systems: A dict of data representing the available
+        systems.
+        { "username1": {"max_bindings" : 2},
+          "username2": {"max_bindings" : 1}
+        }
+        """
+        super(SMPPServerConfig, self).__init__(**kwargs)
+        self.systems = kwargs.get('systems', {})
+        self.msgHandler = kwargs['msgHandler']
+        

--- a/smpp/twisted/protocol.py
+++ b/smpp/twisted/protocol.py
@@ -1,6 +1,6 @@
 """
 Copyright 2009-2010 Mozes, Inc.
-
+ 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -13,14 +13,22 @@ Copyright 2009-2010 Mozes, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import struct, logging, sys, StringIO, binascii
+
+import struct, logging, StringIO, binascii
 from enum import Enum
+
 from smpp.pdu.namedtuple import namedtuple    
-from twisted.internet import protocol, defer, reactor
 from smpp.pdu.operations import *
 from smpp.pdu.pdu_encoding import PDUEncoder
 from smpp.pdu.pdu_types import PDURequest, PDUResponse, PDUDataRequest, CommandStatus
 from smpp.pdu.error import *
+from smpp.pdu.constants import command_status_name_map
+
+from twisted.internet import protocol, defer, reactor
+from twisted.internet.defer import inlineCallbacks
+from twisted.cred import error
+import exceptions
+
 
 LOG_CATEGORY="smpp.twisted.protocol"
 
@@ -41,31 +49,39 @@ SMPPSessionStates = Enum(
 SMPPOutboundTxn = namedtuple('SMPPOutboundTxn', 'request, timer, ackDeferred')
 SMPPOutboundTxnResult = namedtuple('SMPPOutboundTxnResult', 'smpp, request, response')
 
+def _safelylogOutPdu(content):
+    try:
+        return binascii.b2a_hex(content)
+    except exceptions.UnicodeEncodeError:
+        return "Couldn't log out the pdu content due to non-ascii characters."
+
+
 class DataHandlerResponse(object):
     
     def __init__(self, status, **params):
         self.status = status
         self.params = params
 
-class SMPPClientProtocol( protocol.Protocol ):
+class SMPPProtocolBase( protocol.Protocol ):
     """Short Message Peer to Peer Protocol v3.4 implementing ESME (client)"""
     version = 0x34
 
     def __init__( self ):
-        self.log = logging.getLogger(LOG_CATEGORY)
         self.recvBuffer = ""
         self.connectionCorrupted = False
         self.pduReadTimer = None
         self.enquireLinkTimer = None
         self.inactivityTimer = None
-        self.lastSeqNum = 0
         self.dataRequestHandler = None
-        self.alertNotificationHandler = None
+        self.lastSeqNum = 0
         self.inTxns = {}
         self.outTxns = {}
         self.sessionState = SMPPSessionStates.NONE
         self.encoder = PDUEncoder()
         self.disconnectedDeferred = defer.Deferred()
+        # Overriden in tests
+        self.callLater = reactor.callLater
+        self.port = None
 
     def config(self):
         return self.factory.getConfig()
@@ -74,19 +90,20 @@ class SMPPClientProtocol( protocol.Protocol ):
         """When TCP connection is made
         """
         protocol.Protocol.connectionMade(self)
+        self.port = self.transport.getHost().port
 
         self.sessionState = SMPPSessionStates.OPEN
-        self.log.warning("Connection established")
+        self.log.warning("SMPP connection established from %s to port %s", self.transport.getPeer().host, self.port)
 
     def connectionLost( self, reason ):
         protocol.Protocol.connectionLost( self, reason )
-        self.log.warning("Disconnected: %s" % reason)
+        self.log.warning("SMPP %s disconnected from port %s: %s", self.transport.getPeer().host, self.port, reason)
         
         self.sessionState = SMPPSessionStates.NONE
-
+                    
         self.cancelEnquireLinkTimer()
         self.cancelInactivityTimer()
-
+        
         self.disconnectedDeferred.callback(None)
 
     def dataReceived( self, data ):
@@ -94,7 +111,7 @@ class SMPPClientProtocol( protocol.Protocol ):
         rawMessageReceived.
         """
         # if self.log.isEnabledFor(logging.DEBUG):
-        #     self.log.debug("Received data [%s]" % binascii.b2a_hex(data))
+        #     self.log.debug("Received data [%s]" % _safelylogOutPdu(data))
         
         self.recvBuffer = self.recvBuffer + data
         
@@ -113,7 +130,7 @@ class SMPPClientProtocol( protocol.Protocol ):
     def incompletePDURead(self):
         if self.pduReadTimer and self.pduReadTimer.active():
             return
-        self.pduReadTimer = reactor.callLater(self.config().pduReadTimerSecs, self.onPDUReadTimeout)
+        self.pduReadTimer = self.callLater(self.config().pduReadTimerSecs, self.onPDUReadTimeout)
 
     def endPDURead(self):
         if self.pduReadTimer and self.pduReadTimer.active():
@@ -177,11 +194,11 @@ class SMPPClientProtocol( protocol.Protocol ):
             pdu = self.encoder.decode(StringIO.StringIO(message))
         except PDUCorruptError, e:
             self.log.exception(e)
-            self.log.critical("Received corrupt PDU %s" % binascii.b2a_hex(message))
+            self.log.critical("Received corrupt PDU %s" % _safelylogOutPdu(message))
             self.corruptDataRecvd(status=e.status)
         except PDUParseError, e:
             self.log.exception(e)
-            self.log.critical("Received unparsable PDU %s" % binascii.b2a_hex(message))
+            self.log.critical("Received unparsable PDU %s" % _safelylogOutPdu(message))
             header = self.getHeader(message)
             seqNum = header.get('sequence_number', None)
             commandId = header.get('command_id', None)
@@ -194,6 +211,11 @@ class SMPPClientProtocol( protocol.Protocol ):
         """
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug("Received PDU: %s" % pdu)
+        
+        encoded = self.encoder.encode(pdu)
+        
+        if self.log.isEnabledFor(logging.DEBUG):
+            self.log.debug("Receiving data [%s]" % _safelylogOutPdu(encoded))
         
         #Signal SMPP operation
         self.onSMPPOperation()
@@ -211,37 +233,8 @@ class SMPPClientProtocol( protocol.Protocol ):
         if isinstance(reqPDU, PDUDataRequest):
             self.PDUDataRequestReceived(reqPDU)
             return
-            
+        
         getattr(self, "onPDURequest_%s" % str(reqPDU.id))(reqPDU)
-        
-    def onPDU_outbind(self, pdu):
-        if self.sessionState != SMPPSessionStates.OPEN:
-            self.log.critical('Received outbind command in invalid state %s' % str(self.sessionState))
-            self.shutdown()
-            return
-            
-        self.log.warning("Received outbind command")
-        self.doBindAsReceiver()
-        
-    def onPDU_alert_notification(self, pdu):
-        if self.sessionState == SMPPSessionStates.UNBIND_PENDING:
-            self.log.info("Unbind is pending...Ignoring alert notification PDU %s" % pdu)
-            return
-            
-        if not self.isBound():
-            errMsg = 'Received alert notification when not bound %s' % pdu
-            self.cancelOutboundTransactions(SessionStateError(errMsg, CommandStatus.ESME_RINVBNDSTS))
-            self.log.critical(errMsg)
-            self.shutdown()
-            return
-            
-        if self.alertNotificationHandler:
-            try:
-                self.alertNotificationHandler(self, pdu)
-            except Exception, e:
-                self.log.critical('Alert handler threw exception: %s' % str(e))
-                self.log.exception(e)
-                self.shutdown
         
     def onPDURequest_enquire_link(self, reqPDU):
         self.sendResponse(reqPDU)
@@ -305,12 +298,24 @@ class SMPPClientProtocol( protocol.Protocol ):
             self.sendResponse(reqPDU, status, **params)
         
     def PDURequestFailed(self, error, reqPDU):
-        self.log.critical('Exception raised handling inbound PDU [%s] hex[%s]: %s' % (reqPDU, binascii.b2a_hex(self.encoder.encode(reqPDU)), error))
+        if error.check(SMPPProtocolError):
+            # Get the original error
+            try:
+                error.raiseException()
+            except SMPPProtocolError as validation_error:
+                self.log.warning("SMPP Custom Validation error handling inbound PDU [%s] hex[%s]: %s'" % (reqPDU, _safelylogOutPdu(self.encoder.encode(reqPDU)), validation_error))
+                return_cmd_status = validation_error.commandStatusName
+                shutdown = False
+        else:
+            self.log.critical('Exception raised handling inbound PDU [%s] hex[%s]: %s' % (reqPDU, _safelylogOutPdu(self.encoder.encode(reqPDU)), error))
+            return_cmd_status = CommandStatus.ESME_RX_T_APPN
+            shutdown = True
         
         if reqPDU.requireAck:
-            self.sendResponse(reqPDU, CommandStatus.ESME_RX_T_APPN)
-            
-        self.shutdown()
+            self.sendResponse(reqPDU, return_cmd_status)
+        
+        if shutdown:
+            self.shutdown()
 
     def PDURequestFinished(self, result, reqPDU):
         self.endInboundTransaction(reqPDU)                    
@@ -347,8 +352,8 @@ class SMPPClientProtocol( protocol.Protocol ):
             self.log.debug("Sending PDU: %s" % pdu)
         encoded = self.encoder.encode(pdu)
         
-        # if self.log.isEnabledFor(logging.DEBUG):
-        #     self.log.debug("Sending data [%s]" % binascii.b2a_hex(encoded))
+        if self.log.isEnabledFor(logging.DEBUG):
+            self.log.debug("Sending data [%s]" % _safelylogOutPdu(encoded))
         
         self.transport.write( encoded )
         self.onSMPPOperation()
@@ -381,14 +386,14 @@ class SMPPClientProtocol( protocol.Protocol ):
         if self.enquireLinkTimer and self.enquireLinkTimer.active():
             self.enquireLinkTimer.reset(self.config().enquireLinkTimerSecs)
         elif self.config().enquireLinkTimerSecs:
-            self.enquireLinkTimer = reactor.callLater(self.config().enquireLinkTimerSecs, self.enquireLinkTimerExpired)
-            
-    def activateInactivityTimer(self):
+            self.enquireLinkTimer = self.callLater(self.config().enquireLinkTimerSecs, self.enquireLinkTimerExpired)
+       
+    def activateInactivityTimer(self): 
         if self.inactivityTimer and self.inactivityTimer.active():
             self.inactivityTimer.reset(self.config().inactivityTimerSecs)
         elif self.config().inactivityTimerSecs:
-            self.inactivityTimer = reactor.callLater(self.config().inactivityTimerSecs, self.inactivityTimerExpired)
-    
+            self.inactivityTimer = self.callLater(self.config().inactivityTimerSecs, self.inactivityTimerExpired)
+                
     def cancelEnquireLinkTimer(self):
         if self.enquireLinkTimer and self.enquireLinkTimer.active():
             self.enquireLinkTimer.cancel()
@@ -398,9 +403,14 @@ class SMPPClientProtocol( protocol.Protocol ):
         if self.inactivityTimer and self.inactivityTimer.active():
             self.inactivityTimer.cancel()
             self.inactivityTimer = None
-            
+
     def enquireLinkTimerExpired(self):
-        self.sendRequest(EnquireLink(), self.config().responseTimerSecs)
+        txn = self.sendRequest(EnquireLink(), self.config().responseTimerSecs)
+        txn.addErrback(self.enquireLinkErr)
+    
+    def enquireLinkErr(self, failure):
+        # Unbinding already anyway. No need to raise another error
+        failure.trap(SMPPError)
 
     def inactivityTimerExpired(self):
         self.log.critical("Inactivity timer expired...shutting down")
@@ -444,7 +454,7 @@ class SMPPClientProtocol( protocol.Protocol ):
         #Create callback deferred
         ackDeferred = defer.Deferred()
         #Create response timer
-        timer = reactor.callLater(timeout, self.onResponseTimeout, reqPDU, timeout)
+        timer = self.callLater(timeout, self.onResponseTimeout, reqPDU, timeout)
         #Save transaction
         self.outTxns[reqPDU.seqNum] = SMPPOutboundTxn(reqPDU, timer, ackDeferred)
         self.log.debug("Outbound transaction started with message id %s" % reqPDU.seqNum)
@@ -480,7 +490,7 @@ class SMPPClientProtocol( protocol.Protocol ):
         txn.ackDeferred.errback(SMPPTransactionError(respPDU, txn.request))
         
     def endOutboundTransactionErr(self, reqPDU, error):
-        self.log.exception(error)
+        self.log.error(error)
         txn = self.closeOutboundTransaction(reqPDU.seqNum)
         #Do errback
         txn.ackDeferred.errback(error)
@@ -491,7 +501,6 @@ class SMPPClientProtocol( protocol.Protocol ):
 
     def onResponseTimeout(self, reqPDU, timeout):
         errMsg = 'Request timed out after %s secs: %s' % (timeout, reqPDU)
-        self.log.critical(errMsg)
         self.endOutboundTransactionErr(reqPDU, SMPPRequestTimoutError(errMsg))
         self.shutdown()
     
@@ -499,19 +508,6 @@ class SMPPClientProtocol( protocol.Protocol ):
         self.lastSeqNum += 1
         return self.lastSeqNum
             
-    def bindSucceeded(self, result, nextState):
-        self.sessionState = nextState
-        self.log.warning("Bind succeeded...now in state %s" % str(self.sessionState))
-        self.activateEnquireLinkTimer()
-        return result
-        
-    def bindFailed(self, reason):
-        self.log.error("Bind failed [%s]. Disconnecting..." % reason)
-        self.disconnect()
-        if reason.check(SMPPRequestTimoutError):
-            raise SMPPSessionInitTimoutError(str(reason))
-        return reason
-        
     def unbindSucceeded(self, result):
         self.sessionState = SMPPSessionStates.UNBOUND
         self.log.warning("Unbind succeeded")
@@ -524,6 +520,85 @@ class SMPPClientProtocol( protocol.Protocol ):
             raise SMPPSessionInitTimoutError(str(reason))
         return reason
         
+    def unbindAfterInProgressTxnsFinished(self, result, unbindDeferred):
+        self.log.warning('Issuing unbind request')
+        self.sendBindRequest(Unbind()).addCallbacks(self.unbindSucceeded, self.unbindFailed).chainDeferred(unbindDeferred)
+        
+    ############################################################################
+    # Public command functions
+    ############################################################################
+    def unbind(self):
+        """Unbind from SMSC
+        
+        Result is a Deferred object
+        """
+        if not self.isBound():
+            return defer.fail(SMPPClientSessionStateError('unbind called with illegal session state: %s' % self.sessionState))
+
+        self.cancelEnquireLinkTimer()
+        
+        self.log.info('Waiting for in-progress transactions to finish...')
+                
+        #Signal that
+        #   - no new data requests should be sent
+        #   - no new incoming data requests should be accepted
+        self.sessionState = SMPPSessionStates.UNBIND_PENDING
+                
+        unbindDeferred = defer.Deferred()
+        #Wait for any in-progress txns to finish
+        self.finishTxns().addCallback(self.unbindAfterInProgressTxnsFinished, unbindDeferred)
+        #Result is the deferred for the unbind txn
+        return unbindDeferred
+    
+    def unbindAndDisconnect(self):
+        """Unbind from SMSC and disconnect
+        
+        Result is a Deferred object
+        """
+        return self.unbind().addBoth(lambda result: self.disconnect())
+    
+    def disconnect(self):
+        """Disconnect from SMSC
+        """
+        if self.isBound():
+            self.log.warning("Disconnecting while bound to SMSC...")
+        else:
+            self.log.warning("Disconnecting...")
+        self.sessionState = SMPPSessionStates.UNBOUND
+        self.transport.loseConnection()
+        
+    def getDisconnectedDeferred(self):
+        """Get a Deferred so you can be notified on disconnect
+        """
+        return self.disconnectedDeferred
+            
+    def sendDataRequest( self, pdu ):
+        """Send a SMPP Request Message
+
+        Argument is an SMPP PDUDataRequest (protocol data unit).
+        Result is a Deferred object
+        """
+        if not isinstance( pdu, PDUDataRequest ):
+            return defer.fail(SMPPClientError("Invalid PDU passed to sendDataRequest(): %s" % pdu))
+        if not self.isBound():
+            return defer.fail(SMPPClientSessionStateError('Not bound'))
+        return self.sendRequest(pdu, self.config().responseTimerSecs)
+        
+        
+class SMPPClientProtocol(SMPPProtocolBase):
+    
+    def __init__(self):
+	self.log = logging.getLogger(LOG_CATEGORY)
+        SMPPProtocolBase.__init__(self)
+        
+        self.alertNotificationHandler = None
+        
+    def PDUReceived( self, pdu ):
+        """Dispatches incoming PDUs
+        """
+        self.log.info("SMPP Client received PDU [command: %s, sequence_number: %s, command_status: %s]" % (pdu.id, pdu.seqNum, pdu.status))
+        SMPPProtocolBase.PDUReceived(self, pdu)
+    
     def bind(self, pdu, pendingState, boundState):
         if self.sessionState != SMPPSessionStates.OPEN:
             return defer.fail(SMPPClientSessionStateError('bind called with illegal session state: %s' % self.sessionState))
@@ -533,11 +608,7 @@ class SMPPClientProtocol( protocol.Protocol ):
         bindDeferred.addErrback(self.bindFailed)
         self.sessionState = pendingState
         return bindDeferred
-        
-    def unbindAfterInProgressTxnsFinished(self, result, unbindDeferred):
-        self.log.warning('Issuing unbind request')
-        self.sendBindRequest(Unbind()).addCallbacks(self.unbindSucceeded, self.unbindFailed).chainDeferred(unbindDeferred)
-        
+    
     def doBindAsReceiver(self):
         self.log.warning('Requesting bind as receiver')
         pdu = BindReceiver(
@@ -550,10 +621,52 @@ class SMPPClientProtocol( protocol.Protocol ):
             interface_version = self.version
         )
         return self.bind(pdu, SMPPSessionStates.BIND_RX_PENDING, SMPPSessionStates.BOUND_RX)
+    
+    def bindSucceeded(self, result, nextState):
+        self.sessionState = nextState
+        self.log.warning("Bind succeeded...now in state %s" % str(self.sessionState))
+        self.activateEnquireLinkTimer()
+        return result
         
-    #
+    def bindFailed(self, reason):
+        self.log.error("Bind failed [%s]. Disconnecting..." % reason)
+        self.disconnect()
+        if reason.check(SMPPRequestTimoutError):
+            raise SMPPSessionInitTimoutError(str(reason))
+        return reason
+    
+    def onPDU_outbind(self, pdu):
+        if self.sessionState != SMPPSessionStates.OPEN:
+            self.log.critical('Received outbind command in invalid state %s' % str(self.sessionState))
+            self.shutdown()
+            return
+            
+        self.log.warning("Received outbind command")
+        self.doBindAsReceiver()
+        
+    def onPDU_alert_notification(self, pdu):
+        if self.sessionState == SMPPSessionStates.UNBIND_PENDING:
+            self.log.info("Unbind is pending...Ignoring alert notification PDU %s" % pdu)
+            return
+            
+        if not self.isBound():
+            errMsg = 'Received alert notification when not bound %s' % pdu
+            self.cancelOutboundTransactions(SessionStateError(errMsg, CommandStatus.ESME_RINVBNDSTS))
+            self.log.critical(errMsg)
+            self.shutdown()
+            return
+            
+        if self.alertNotificationHandler:
+            try:
+                self.alertNotificationHandler(self, pdu)
+            except Exception, e:
+                self.log.critical('Alert handler threw exception: %s' % str(e))
+                self.log.exception(e)
+                self.shutdown()
+    
+    ############################################################################
     # Public command functions
-    #
+    ############################################################################
     def bindAsTransmitter(self):
         """Bind to SMSC as transmitter
         
@@ -596,63 +709,6 @@ class SMPPClientProtocol( protocol.Protocol ):
             interface_version = self.version
         )
         return self.bind(pdu, SMPPSessionStates.BIND_TRX_PENDING, SMPPSessionStates.BOUND_TRX)
-    
-    def unbind(self):
-        """Unbind from SMSC
-        
-        Result is a Deferred object
-        """
-        if not self.isBound():
-            return defer.fail(SMPPClientSessionStateError('unbind called with illegal session state: %s' % self.sessionState))
-        
-        self.cancelEnquireLinkTimer()
-        
-        self.log.info('Waiting for in-progress transactions to finish...')
-                
-        #Signal that
-        #   - no new data requests should be sent
-        #   - no new incoming data requests should be accepted
-        self.sessionState = SMPPSessionStates.UNBIND_PENDING
-                
-        unbindDeferred = defer.Deferred()
-        #Wait for any in-progress txns to finish
-        self.finishTxns().addCallback(self.unbindAfterInProgressTxnsFinished, unbindDeferred)
-        #Result is the deferred for the unbind txn
-        return unbindDeferred
-            
-    def unbindAndDisconnect(self):
-        """Unbind from SMSC and disconnect
-        
-        Result is a Deferred object
-        """
-        return self.unbind().addBoth(lambda result: self.disconnect())
-    
-    def disconnect(self):
-        """Disconnect from SMSC
-        """
-        if self.isBound():
-            self.log.warning("Disconnecting while bound to SMSC...")
-        else:
-            self.log.warning("Disconnecting...")
-        self.sessionState = SMPPSessionStates.UNBOUND
-        self.transport.loseConnection()
-    
-    def sendDataRequest( self, pdu ):
-        """Send a SMPP Request Message
-
-        Argument is an SMPP PDUDataRequest (protocol data unit).
-        Result is a Deferred object
-        """
-        if not isinstance( pdu, PDUDataRequest ):
-            return defer.fail(SMPPClientError("Invalid PDU passed to sendDataRequest(): %s" % pdu))
-        if not self.isBound():
-            return defer.fail(SMPPClientSessionStateError('Not bound'))
-        return self.sendRequest(pdu, self.config().responseTimerSecs)
-        
-    def getDisconnectedDeferred(self):
-        """Get a Deferred so you can be notified on disconnect
-        """
-        return self.disconnectedDeferred
         
     def setDataRequestHandler(self, handler):
         """Set handler to use for receiving data requests
@@ -663,3 +719,90 @@ class SMPPClientProtocol( protocol.Protocol ):
         """Set handler to use for receiving data requests
         """
         self.alertNotificationHandler = handler
+
+
+class SMPPServerProtocol(SMPPProtocolBase):
+    
+    def __init__(self):
+        SMPPProtocolBase.__init__(self)
+        # Divert received messages to the handler defined in the config
+        self.dataRequestHandler = lambda *args, **kwargs: self.config().msgHandler(self.system_id, *args, **kwargs)
+        self.system_id = None
+        self.log = logging.getLogger(LOG_CATEGORY)
+       
+    def onResponseTimeout(self, reqPDU, timeout):
+        errMsg = 'Request timed out for system id %s after %s secs: %s' % (self.system_id, timeout, reqPDU)       
+        self.endOutboundTransactionErr(reqPDU, SMPPRequestTimoutError(errMsg))
+        self.shutdown()
+ 
+    def connectionLost(self, reason):
+        SMPPProtocolBase.connectionLost(self, reason)
+        # Remove this connection from those stored in the factory
+        self.factory.removeConnection(self)
+        
+    def PDUReceived( self, pdu ):
+        """Dispatches incoming PDUs
+        """
+        self.log.debug("SMPP Server received PDU to system '%s' [command: %s, sequence_number: %s, command_status: %s]" % (self.system_id, pdu.id, pdu.seqNum, pdu.status))
+        SMPPProtocolBase.PDUReceived(self, pdu)
+
+    def onPDURequest_enquire_link(self, reqPDU):
+        if self.isBound():
+            self.sendResponse(reqPDU)
+        else:
+            self.sendResponse(reqPDU, status=CommandStatus.ESME_RINVBNDSTS)
+        
+    def onPDURequest_bind_receiver(self, reqPDU):
+        self.doBindRequest(reqPDU, SMPPSessionStates.BOUND_RX)
+    
+    def onPDURequest_bind_transmitter(self, reqPDU):
+        self.doBindRequest(reqPDU, SMPPSessionStates.BOUND_TX)
+    
+    def onPDURequest_bind_transceiver(self, reqPDU):
+        self.doBindRequest(reqPDU, SMPPSessionStates.BOUND_TRX)
+    
+    @inlineCallbacks
+    def doBindRequest(self, reqPDU, sessionState):
+        # Check the authentication
+        system_id, password = reqPDU.params['system_id'], reqPDU.params['password']
+
+        # Authenticate system_id and password
+        try:
+            iface, auth_avatar, logout = yield self.factory.login(system_id, password, self.transport.getPeer().host)
+        except error.UnauthorizedLogin:
+            if system_id not in self.factory.config.systems.keys():
+                self.log.warning('SMPP Bind request failed for system_id: "%s", System ID not configured' % system_id)
+                self.sendErrorResponse(reqPDU, CommandStatus.ESME_RINVSYSID, system_id)
+            else:
+                self.log.warning('SMPP Bind request failed for system_id: "%s", failed to authenticate' % system_id)
+                self.sendErrorResponse(reqPDU, CommandStatus.ESME_RINVPASWD, system_id)
+            return
+        
+        # Check we're not already bound, and are open to being bound
+        if self.sessionState != SMPPSessionStates.OPEN:
+            self.log.warning('Duplicate SMPP bind request received from: %s' % system_id)
+            self.sendErrorResponse(reqPDU, CommandStatus.ESME_RALYBND, system_id)
+            return
+        
+        # Check that system_id hasn't exceeded number of allowed binds
+        bind_type = reqPDU.commandId
+        if not self.factory.canOpenNewConnection(system_id, bind_type):
+            self.log.warning('SMPP System %s has exceeded maximum number of %s bindings' % (system_id, bind_type))
+            self.sendErrorResponse(reqPDU, CommandStatus.ESME_RBINDFAIL, system_id)
+            return
+        
+        # If we get to here, bind successfully
+        self.system_id = system_id
+        self.sessionState = sessionState
+        self.bind_type = bind_type
+        
+        self.factory.addBoundConnection(self)
+        bound_cnxns = self.factory.getBoundConnections(system_id)
+        self.log.info('Bind request succeeded for %s. %d active binds' % (system_id, bound_cnxns.getBindingCount() if bound_cnxns else 0))
+        self.sendResponse(reqPDU, system_id=system_id)
+        
+    def sendErrorResponse(self, reqPDU, status, system_id):
+        """ Send an error response to reqPDU, with the specified command status."""
+        err_pdu = reqPDU.requireAck(seqNum=reqPDU.seqNum, status=status, system_id=system_id)
+        self.sendPDU(err_pdu)
+

--- a/smpp/twisted/server.py
+++ b/smpp/twisted/server.py
@@ -1,0 +1,190 @@
+from smpp.twisted.protocol import SMPPServerProtocol
+from smpp.pdu import pdu_types
+
+from zope.interface import Interface
+
+from twisted.internet.protocol import ServerFactory
+from twisted import cred
+from twisted.cred import error
+from twisted.internet import defer
+
+import logging
+import collections
+
+
+LOG_CATEGORY="smpp.twisted.server"
+
+class IAuthenticatedSMPP(Interface):
+    pass
+
+class UsernameAndPasswordAndIP(cred.credentials.UsernamePassword):
+    def __init__(self, username, password, client_ip_address):
+        self.username = username
+        self.password = password
+        self.client_ip_address = client_ip_address
+    
+class SMPPServerFactory(ServerFactory):
+
+    protocol = SMPPServerProtocol
+
+    def __init__(self, config, auth_portal):
+        self.config = config
+        self.log = logging.getLogger(LOG_CATEGORY)
+        # A dict of protocol instances for each of the current connections,
+        # indexed by system_id 
+        self.bound_connections = {}
+        self._auth_portal = auth_portal
+    
+    def getConfig(self):
+        return self.config
+
+    def addBoundConnection(self, connection):
+        """
+        Add a protocol instance to the list of current connections.
+        @param connection: An instance of SMPPServerProtocol
+        """
+        system_id = connection.system_id
+        self.log.debug('Adding SMPP binding for %s' % system_id)
+        if not system_id in self.bound_connections:
+            self.bound_connections[system_id] = SMPPBindManager(system_id)
+        self.bound_connections[system_id].addBinding(connection)
+        self.log.debug("'%s' now has %d bound SMPP connections" % (system_id, self.bound_connections[system_id].getBindingCount()))
+        
+    def removeConnection(self, connection):
+        """
+        Remove a protocol instance (SMPP binding) from the list of current connections.
+        @param connection: An instance of SMPPServerProtocol
+        """
+        if connection.system_id is None:
+            logging.debug("SMPP connection attempt failed without binding.")
+        else:
+            system_id = connection.system_id
+            self.log.debug('Dropping SMPP binding for: %s. %d remain bound for this user' % (system_id, self.bound_connections[system_id].getBindingCount()-1))
+            self.bound_connections[system_id].removeBinding(connection)
+            # If this is the last binding for this service then remove the BindManager
+            if self.bound_connections[system_id].getBindingCount() == 0:
+                self.bound_connections.pop(system_id)
+        
+    def getBoundConnections(self, system_id):
+        return self.bound_connections.get(system_id)
+    
+    def login(self, system_id, password, client_ip_address):
+        if self._auth_portal is not None:
+            return self._auth_portal.login(
+                UsernameAndPasswordAndIP(system_id, password, client_ip_address),
+                None,
+                IAuthenticatedSMPP
+            )
+        raise error.UnauthorizedLogin()
+        
+    def canOpenNewConnection(self, system_id, bind_type):
+        """
+        Checks if the gateway with the specified system_id can open a new
+        connection, as it hasn't exceeded its maximum number of bindings.
+        @param bind_type: One of smpp.pdu.pdu_types.CommandId
+        """
+        existing_bindings_for_id = self.getBoundConnections(system_id)
+        if existing_bindings_for_id:
+            connections_count = existing_bindings_for_id.getBindingCountForType(bind_type)
+            return connections_count < self.config.systems[system_id]['max_bindings']
+        else:
+            # No existing bindings for this system_id
+            return self.config.systems[system_id]['max_bindings'] > 0
+        
+    def unbindGateway(self, system_id):
+        """ Unbinds and disconnects all the bindings for the given system_id.  """
+        bind_mgr = self.getBoundConnections(system_id)
+        if bind_mgr:
+            unbinds_list = [binding.unbind() for binding in bind_mgr]
+            d = defer.DeferredList(unbinds_list)
+            if unbinds_list:
+                # Disconnect from the remote server (apply via any of the (now unbound) bindings)
+                d.addCallback(lambda r: binding.disconnect())
+        else:
+            d = defer.succeed(None)
+        self
+        return d
+
+
+class SMPPBindManager(object):
+    
+    def __init__(self, system_id):
+        self.system_id = system_id
+        self._binds = {pdu_types.CommandId.bind_transceiver: [],
+                       pdu_types.CommandId.bind_transmitter: [],
+                       pdu_types.CommandId.bind_receiver: []}
+        # A queue of the most recent bindings used for delivering messages
+        self._delivery_binding_history = collections.deque()
+        
+    def addBinding(self, connection):
+        """ @param connection: An instance of SMPPServerProtocol """
+        
+        bind_type = connection.bind_type
+        self._binds[bind_type].append(connection)
+        
+    def removeBinding(self, connection):
+        """ @param connection: An instance of SMPPServerProtocol """
+        bind_type = connection.bind_type
+        self._binds[bind_type].remove(connection)
+        
+    def getBindingCount(self):
+        return sum(len(v) for v in self._binds.values())
+    
+    def __len__(self):
+        return self.getBindingCount()
+    
+    def __iter__(self):
+        vals = []
+        [vals.extend(type) for type in self._binds.values()]
+        return vals.__iter__()
+    
+    def getBindingCountForType(self, bind_type):
+        """
+        Sum transceiver binds plus receiver or transmitter depending on this type
+        @param bind_type: One of smpp.pdu.pdu_types.CommandId
+        """
+        if bind_type == pdu_types.CommandId.bind_transceiver:
+            # Sum of current transceiver binds plus greater of current transmitter or receiver binds
+            connections_count = len(self._binds[pdu_types.CommandId.bind_transceiver]) + \
+                                max(len(self._binds[pdu_types.CommandId.bind_transmitter]),
+                                    len(self._binds[pdu_types.CommandId.bind_receiver]))
+        else:
+            # Sum of transceiver binds plus existing binds of this type
+            connections_count = sum([len(self._binds[bt]) for bt in (pdu_types.CommandId.bind_transceiver,bind_type)])
+        return connections_count
+    
+    def getNextBindingForDelivery(self):
+        """
+        Messages inbound (MO) that are to be forwarded to
+        the client systems can be sent via transceiver and
+        receiver bindings. Call this method to determine which
+        binding to send down next so that traffic travels equally
+        down the different binds.
+        """
+        binding = None
+        # If we now have more trx/rx bindings than have been used
+        # then iterate through our trx/rx binds until we find one
+        # that hasn't yet been used
+        if len(self._delivery_binding_history) < self.getBindingCountForType(pdu_types.CommandId.bind_receiver):
+            for binding in self._binds[pdu_types.CommandId.bind_receiver] + self._binds[pdu_types.CommandId.bind_transceiver]:
+                if not binding in self._delivery_binding_history:
+                    break
+            else:
+                binding = None
+        
+        # Otherwise send on the last trx/rx binding delivered on, as
+        # long as it is still bound
+        while binding is None and self._delivery_binding_history:
+            # get last binding used
+            _binding = self._delivery_binding_history.popleft()
+            # check it is still bound
+            if _binding in self._binds[_binding.bind_type]:
+                # If so then use it
+                binding = _binding
+        
+        if binding is None:
+            logging.warning("Couldn't find a binding to use to deliver SMPP message")
+        else:    
+            self._delivery_binding_history.append(binding)
+        return binding
+        

--- a/smpp/twisted/tests/test_smpp_server.py
+++ b/smpp/twisted/tests/test_smpp_server.py
@@ -1,0 +1,506 @@
+import unittest
+import logging
+from twisted.web import resource
+from twisted.internet import defer, reactor, task
+from twisted.application import internet
+from twisted.trial.unittest import TestCase
+from twisted.cred.portal import IRealm    
+from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
+from twisted.cred.portal import Portal
+from twisted.test import proto_helpers
+from zope.interface import implements      
+
+from smpp.twisted.config import SMPPServerConfig, SMPPClientConfig
+from smpp.twisted.server import SMPPServerFactory, SMPPBindManager
+from smpp.twisted.protocol import SMPPSessionStates, DataHandlerResponse
+from smpp.twisted.client import SMPPClientTransceiver
+
+from smpp.pdu import pdu_types, operations, pdu_encoding
+
+import mock
+
+logging.basicConfig(level = logging.DEBUG)
+
+def _makeMockServerConnection(key, bind_type):
+    mk_server_cnxn = mock.Mock('mock svr cnxn')
+    mk_server_cnxn.system_id = key
+    mk_server_cnxn.bind_type = bind_type
+    return mk_server_cnxn
+    
+class SMPPServerFactoryTests(unittest.TestCase):
+
+    def setUp(self):
+        self.config = mock.Mock('mock smpp config')
+        self.config.systems = {'lala': {'max_bindings': 2}}
+    
+    def tearDown(self):
+        pass
+        
+    def test_canOpenNewConnection_transceiver(self):
+        server = SMPPServerFactory(self.config, None)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should be able to bind trx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should be able to bind tx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should be able to bind rx as none bound yet')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_transceiver)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx bound')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_transceiver)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as two trx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertFalse(can_bind, 'Should not be able to bind as two trx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as two trx already bound')
+        
+    def test_canOpenNewConnection_transmitter(self):
+        server = SMPPServerFactory(self.config, None)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should be able to bind trx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should be able to bind tx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should be able to bind rx as none bound yet')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_transmitter)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one tx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one tx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should still be able to bind only bindings are tx')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_transmitter)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as two tx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertFalse(can_bind, 'Should not be able to bind as two tx already bound')
+        # NOTE this one different
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should still be able to bind only bindings are tx')
+        
+    def test_canOpenNewConnection_receiver(self):
+        server = SMPPServerFactory(self.config, None)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should be able to bind trx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should be able to bind tx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should be able to bind rx as none bound yet')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_receiver)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one rx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should still be able to bind only bindings are rx')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one rx bound')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_receiver)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as two rx already bound')
+        # NOTE this one different
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should still be able to bind only bindings are rx')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as two rx already bound')
+        
+    def test_canOpenNewConnection_multitypes(self):
+        server = SMPPServerFactory(self.config, None)
+        
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should be able to bind trx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should be able to bind tx as none bound yet')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should be able to bind rx as none bound yet')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_transceiver)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx bound')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_transmitter)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as one trx and one tx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertFalse(can_bind, 'Should not be able to bind as one trx and one tx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertTrue(can_bind, 'Should still be able to bind as only one trx and one tx bound')
+        
+        mk_server_cnxn = _makeMockServerConnection('lala', pdu_types.CommandId.bind_receiver)
+        server.addBoundConnection(mk_server_cnxn)
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transceiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as one trx, one tx, and one rx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_transmitter)
+        self.assertFalse(can_bind, 'Should not be able to bind as one trx, one tx, and one rx already bound')
+        can_bind = server.canOpenNewConnection('lala', pdu_types.CommandId.bind_receiver)
+        self.assertFalse(can_bind, 'Should not be able to bind as one trx, one tx, and one rx already bound')
+        
+
+class SMPPBindManagerTests(unittest.TestCase):
+    
+    def test_getNextBindingForDelivery(self):
+        bm = SMPPBindManager('blah')
+        
+        # add an initial rx
+        mk_server_cnxn_rx1 = _makeMockServerConnection('blah', pdu_types.CommandId.bind_receiver)
+        bm.addBinding(mk_server_cnxn_rx1)
+        
+        # Get the only rx
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx1, deliverer)
+        
+        # Get the only rx again
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx1, deliverer)
+        
+        # Add a new rx
+        mk_server_cnxn_rx2 = _makeMockServerConnection('blah', pdu_types.CommandId.bind_receiver)
+        bm.addBinding(mk_server_cnxn_rx2)
+        
+        # Get the new rx
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx2, deliverer)
+        
+        # Expect the original rx again
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx1, deliverer)
+        
+        # Add a new tx - shouldn't affect deliverer selection at all
+        mk_server_cnxn_tx1 = _makeMockServerConnection('blah', pdu_types.CommandId.bind_transmitter)
+        bm.addBinding(mk_server_cnxn_tx1)
+        
+        # Expect the 2nd rx again
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx2, deliverer)
+
+        # Add a new trx
+        mk_server_cnxn_trx1 = _makeMockServerConnection('blah', pdu_types.CommandId.bind_transceiver)
+        bm.addBinding(mk_server_cnxn_trx1)
+    
+        # Expect the new trx
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_trx1, deliverer)
+        
+        # Remove the 1st rx
+        bm.removeBinding(mk_server_cnxn_rx1)
+        
+        # Expect the 2nd rx again
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx2, deliverer)
+        
+        # Expect the new trx
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_trx1, deliverer)
+        
+        # Expect the 2nd rx again
+        deliverer = bm.getNextBindingForDelivery()
+        self.assertEqual(mk_server_cnxn_rx2, deliverer)
+
+class SMPPServerBaseTest(TestCase):
+    def _serviceHandler(self, system_id, smpp, pdu):
+        self.service_calls.append((system_id, smpp, pdu))
+        return pdu_types.CommandStatus.ESME_ROK
+
+    class SmppRealm(object):
+        implements(IRealm)
+
+        def requestAvatar(self, avatarId, mind, *interfaces):
+            return ('SMPP', avatarId, lambda: None)
+
+    def _bind(self):
+        self.proto.bind_type = pdu_types.CommandId.bind_transceiver
+        self.proto.sessionState = SMPPSessionStates.BOUND_TRX
+        self.proto.system_id = 'userA'
+        self.factory.addBoundConnection(self.proto)
+
+class SMPPServerTestCase(SMPPServerBaseTest):
+
+    def setUp(self):
+        self.service_calls = []
+        self.encoder = pdu_encoding.PDUEncoder()
+        self.smpp_config = SMPPServerConfig(msgHandler=self._serviceHandler,
+                                            systems={'userA': {"max_bindings": 2}}
+                                            )
+        portal = Portal(self.SmppRealm())
+        credential_checker = InMemoryUsernamePasswordDatabaseDontUse()
+        credential_checker.addUser('userA', 'valid')
+        portal.registerChecker(credential_checker)
+        self.factory = SMPPServerFactory(self.smpp_config, auth_portal=portal)
+        self.proto = self.factory.buildProtocol(('127.0.0.1', 0))
+        self.tr = proto_helpers.StringTransport()
+        self.proto.makeConnection(self.tr)
+
+    def tearDown(self):
+        self.proto.connectionLost('test end')
+
+    def testTRXBindRequest(self):
+        pdu = operations.BindTransceiver(
+            system_id = 'userA',
+            password = 'valid',
+            seqNum = 1
+        )
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.BindTransceiverResp(system_id='userA', seqNum=1)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        connection = self.factory.getBoundConnections('userA')
+        self.assertEqual(connection.system_id, 'userA')
+        self.assertEqual(connection._binds[pdu_types.CommandId.bind_transceiver][0], self.proto)
+
+    def testTRXBindRequestInvalidSysId(self):
+        pdu = operations.BindTransceiver(
+            system_id = 'userB',
+            password = 'valid',
+            seqNum = 1
+        )
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.BindTransceiverResp(system_id='userB', seqNum=1, status=pdu_types.CommandStatus.ESME_RINVSYSID)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        connection = self.factory.getBoundConnections('userA')
+        self.assertEqual(connection, None)
+        connection = self.factory.getBoundConnections('userB')
+        self.assertEqual(connection, None)
+
+    def testTRXBindRequestInvalidPassword(self):
+        pdu = operations.BindTransceiver(
+            system_id = 'userA',
+            password = 'invalid',
+            seqNum = 1
+        )
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.BindTransceiverResp(system_id='userA', seqNum=1, status=pdu_types.CommandStatus.ESME_RINVPASWD)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        connection = self.factory.getBoundConnections('userA')
+        self.assertEqual(connection, None)
+ 
+    def testTransmitterBindRequest(self):
+        system_id = 'userA'
+        pdu = operations.BindTransmitter(
+            system_id = system_id,
+            password = 'valid',
+            seqNum = 1
+        )
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.BindTransmitterResp(system_id='userA', seqNum=1)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        self.tr.clear()
+        connection = self.factory.getBoundConnections(system_id)
+        self.assertEqual(connection.system_id, system_id)
+        self.assertEqual(connection._binds[pdu_types.CommandId.bind_transmitter][0], self.proto)
+        bind_manager = self.factory.getBoundConnections(system_id)
+        delivery_binding = bind_manager.getNextBindingForDelivery()
+        self.assertTrue(delivery_binding is None)
+
+    def testReceiverBindRequest(self):
+        system_id = 'userA'
+        pdu = operations.BindReceiver(
+            system_id = system_id,
+            password = 'valid',
+            seqNum = 1
+        )
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.BindReceiverResp(system_id='userA', seqNum=1)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        self.tr.clear()
+        connection = self.factory.getBoundConnections(system_id)
+        self.assertEqual(connection.system_id, system_id)
+        self.assertEqual(connection._binds[pdu_types.CommandId.bind_receiver][0], self.proto)
+        bind_manager = self.factory.getBoundConnections(system_id)
+        delivery_binding = bind_manager.getNextBindingForDelivery()
+        self.assertTrue(delivery_binding is not None)
+        # TODO Identify what should be returned here
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=6)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.SubmitSMResp(seqNum=6)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+
+ 
+    def testUnboundSubmitRequest(self):
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=1)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.SubmitSMResp(status=pdu_types.CommandStatus.ESME_RINVBNDSTS, seqNum=1)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+    
+    def testUnboundSubmitRequest(self):
+        pdu = operations.EnquireLink(seqNum = 576)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.EnquireLinkResp(status=pdu_types.CommandStatus.ESME_RINVBNDSTS, seqNum=576)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+
+    def testTRXUnbindRequest(self):
+        self._bind()
+        pdu = operations.Unbind(seqNum = 346)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.UnbindResp(seqNum=346)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        connection = self.factory.getBoundConnections('userA')
+        self.assertEqual(connection.system_id, 'userA')
+        # Still in list of binds as the connection has not been closed yet. is removed after test tearDown
+        self.assertEqual(connection._binds[pdu_types.CommandId.bind_transceiver][0].sessionState, SMPPSessionStates.UNBOUND)
+ 
+    def testTRXSubmitSM(self):
+        self._bind()
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=6)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.SubmitSMResp(seqNum=6)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        system_id, smpp, pdu_notified = self.service_calls.pop()
+        self.assertEqual(system_id, self.proto.system_id)
+	self.assertEqual(pdu.params['short_message'], pdu_notified.params['short_message'])
+        self.assertEqual(pdu.params['source_addr'], pdu_notified.params['source_addr'])
+        self.assertEqual(pdu.params['destination_addr'], pdu_notified.params['destination_addr'])
+
+    def testTRXDataSM(self):
+        self._bind()
+        pdu = operations.DataSM(source_addr='t1', destination_addr='1208230', short_message='tests', seqNum=6)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.DataSMResp(seqNum=6)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        system_id, smpp, pdu_notified = self.service_calls.pop()
+        self.assertEqual(system_id, self.proto.system_id)
+        
+    def testTRXQuerySM(self):
+        def _serviceHandler(system_id, smpp, pdu):
+            self.service_calls.append((system_id, smpp, pdu))
+            return DataHandlerResponse(status=pdu_types.CommandStatus.ESME_ROK,
+                                       message_id='tests',
+                                       final_date=None,
+                                       message_state=pdu_types.MessageState.ACCEPTED,
+                                       error_code=0)
+        self.proto.dataRequestHandler = lambda *args, **kwargs: _serviceHandler(self.proto.system_id, *args, **kwargs)
+        self._bind()
+        pdu = operations.QuerySM(message_id='tests', source_addr='t1', seqNum=23)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.QuerySMResp(message_id='tests', error_code=0, final_date=None, message_state=pdu_types.MessageState.ACCEPTED ,seqNum=23)
+        # Does not work as application using library must reply correctly.
+        print self.tr.value()
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        system_id, smpp, pdu_notified = self.service_calls.pop()
+        self.assertEqual(system_id, self.proto.system_id)
+ 
+    def testRecievePduWhileUnbindPending(self):
+        self._bind()
+        self.proto.unbind()
+        expected_pdu = operations.Unbind(seqNum=1)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        self.tr.clear()
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=6)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.SubmitSMResp(seqNum=6)
+        self.assertEqual(self.tr.value(), '')
+        pdu = operations.UnbindResp(seqNum=1)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        
+    def testTRXClientUnbindRequestAfterSubmit(self):
+        d = defer.Deferred()
+        def _serviceHandler(system_id, smpp, pdu):
+            logging.debug("%s, %s, %s", system_id, smpp, pdu)
+            return d
+        self.proto.dataRequestHandler = lambda *args, **kwargs: _serviceHandler(self.proto.system_id, *args, **kwargs)
+        self._bind()
+
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=1)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        pdu = operations.Unbind(seqNum = 52)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+
+        #All PDU requests should fail now.
+        #Once we fire this we should get our Submit Resp and the unbind Resp
+	pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='goodbye', seqNum=5)
+	self.proto.dataReceived(self.encoder.encode(pdu))
+
+        unbind_resp_pdu = operations.UnbindResp(seqNum=52)
+        submit_fail_pdu = operations.SubmitSMResp(status=pdu_types.CommandStatus.ESME_RINVBNDSTS, seqNum=5)
+        # We should have a reply here as our service handler should not be called
+        self.assertEqual(self.tr.value(), self.encoder.encode(submit_fail_pdu))
+        self.tr.clear()
+        
+        d.callback(pdu_types.CommandStatus.ESME_ROK)
+        #Then we should get our initial message response and the unbind response
+        expected_pdu = operations.SubmitSMResp(seqNum=1)
+        self.assertEqual(self.tr.value(), '%s%s' % (self.encoder.encode(expected_pdu), self.encoder.encode(unbind_resp_pdu)))
+
+    def testTRXServerUnbindRequestAfterSubmit(self):
+        deferreds = []
+        def _serviceHandler(system_id, smpp, pdu):
+            d = defer.Deferred()
+            deferreds.append(d)
+            logging.debug("%s, %s, %s", system_id, smpp, pdu)
+            return d
+        self.proto.dataRequestHandler = lambda *args, **kwargs: _serviceHandler(self.proto.system_id, *args, **kwargs)
+        self._bind()
+
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=1)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        unbind_d = self.proto.unbind()
+        print self.tr.value()
+
+        pdu2 = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO2', seqNum=2)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        
+        self.assertEqual(1, len(deferreds))
+        self.assertEqual(self.tr.value(), '')
+        self.tr.clear()
+        deferreds[-1].callback(pdu_types.CommandStatus.ESME_ROK)
+        deferreds = deferreds[:-1]
+        submit_resp_pdu = operations.SubmitSMResp(seqNum=1)
+
+        unbind_pdu = operations.Unbind(seqNum=1)
+        # We should have a reply here as our service handler should not be called
+        self.assertEqual(self.tr.value(), '%s%s' % (self.encoder.encode(submit_resp_pdu), self.encoder.encode(unbind_pdu)))
+        self.tr.clear()
+        pdu = operations.UnbindResp(seqNum=1)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+
+class SMPPServerTimeoutTestCase(SMPPServerBaseTest):
+
+    def setUp(self):
+        self.service_calls = []
+        self.clock = task.Clock()
+        self.encoder = pdu_encoding.PDUEncoder()
+        self.smpp_config = SMPPServerConfig(msgHandler=self._serviceHandler,
+                                            systems={'userA': {"max_bindings": 2}},
+                                            enquireLinkTimerSecs=0.1,
+                                            responseTimerSecs=0.1
+                                            )
+        portal = Portal(self.SmppRealm())
+        credential_checker = InMemoryUsernamePasswordDatabaseDontUse()
+        credential_checker.addUser('userA', 'valid')
+        portal.registerChecker(credential_checker)
+        self.factory = SMPPServerFactory(self.smpp_config, auth_portal=portal)
+        self.proto = self.factory.buildProtocol(('127.0.0.1', 0))
+        self.proto.callLater = self.clock.callLater
+        self.tr = proto_helpers.StringTransport()
+        self.proto.makeConnection(self.tr)
+
+    def testEnquireTimeout(self):
+        self._bind()
+        pdu = operations.SubmitSM(source_addr='t1', destination_addr='1208230', short_message='HELLO', seqNum=6)
+        self.proto.dataReceived(self.encoder.encode(pdu))
+        expected_pdu = operations.SubmitSMResp(seqNum=6)
+        self.assertEqual(self.tr.value(), self.encoder.encode(expected_pdu))
+        self.service_calls.pop()
+        self.tr.clear()
+        self.clock.advance(0.1)
+        self.clock.advance(0.1)
+        self.assertEqual(self.proto.sessionState, SMPPSessionStates.UNBIND_PENDING)


### PR DESCRIPTION
Added support for SMPP servers including:
- Bind limits for separate accounts.
- Graceful handling of validation errors, no longer causing unbinds.
- Unit tests.

Logging improvements:
- All messages are logged by smpp.twisted.protocol rather than the root logger.
- Added host and port to log messages when connections are made and lost.
- Gracefully handle logging of PDUs with unprintable characters.
